### PR TITLE
remove toString() for compatability with DJ5

### DIFF
--- a/category.cpp
+++ b/category.cpp
@@ -7,7 +7,7 @@
 namespace DJ {
 namespace Model {
 Category::Category(QJsonObject category, QObject *parent) : QObject(parent) {
-	this->id = category.value("categoryid").toString("0").toInt();
+	this->id = category.value("categoryid").toInt();
 	this->color = category.value("color").toString("");
 	this->name = category.value("name").toString("UNKNOWN");
 }

--- a/contest.cpp
+++ b/contest.cpp
@@ -9,10 +9,10 @@ Contest::Contest(QJsonObject contest, QObject *parent) : QObject(parent) {
 	this->name = contest.value("name").toString("Unknown");
 	this->penaltyMinutes = contest.value("penalty").toInt(0) / 60;
 
-	this->start = QDateTime::fromTime_t(qRound(contest.value("start").toString().toDouble(0)));
-	this->freeze = QDateTime::fromTime_t(qRound(contest.value("freeze").toString().toDouble(0)));
-	this->end = QDateTime::fromTime_t(qRound(contest.value("end").toString().toDouble(0)));
-	this->unfreeze = QDateTime::fromTime_t(qRound(contest.value("unfreeze").toString().toDouble(0)));
+	this->start = QDateTime::fromTime_t(qRound(contest.value("start").toDouble(0)));
+	this->freeze = QDateTime::fromTime_t(qRound(contest.value("freeze").toDouble(0)));
+	this->end = QDateTime::fromTime_t(qRound(contest.value("end").toDouble(0)));
+	this->unfreeze = QDateTime::fromTime_t(qRound(contest.value("unfreeze").toDouble(0)));
 }
 
 Contest::~Contest() {

--- a/judging.cpp
+++ b/judging.cpp
@@ -11,8 +11,8 @@ Judging::Judging(QJsonObject judging,
 				 QHash<int, Submission *> submissions,
 				 QObject *parent) : QObject(parent)
 {
-	this->id = judging.value("id").toString("0").toInt();
-	int submissionId = judging.value("submission").toString("0").toInt();
+	this->id = judging.value("id").toInt();
+	int submissionId = judging.value("submission").toInt();
 	if (submissions.contains(submissionId)) {
 		this->submission = submissions[submissionId];
 	} else {

--- a/problem.cpp
+++ b/problem.cpp
@@ -5,7 +5,7 @@
 namespace DJ {
 namespace Model {
 Problem::Problem(QJsonObject problem, QObject *parent) : QObject(parent) {
-	this->id = problem.value("id").toString("0").toInt();
+	this->id = problem.value("id").toInt();
 	this->color = problem.value("color").toString();
 	this->name = problem.value("name").toString("UNKNOWN");
 	this->shortname = problem.value("shortname").toString("?");

--- a/submission.cpp
+++ b/submission.cpp
@@ -13,22 +13,22 @@ Submission::Submission(QJsonObject submission,
 					   QHash<int, Team *> teams,
 					   QHash<int, Problem *> problems,
 					   QObject *parent) : QObject(parent) {
-	this->id = submission.value("id").toString("0").toInt();
-	int problemId = submission.value("problem").toString("0").toInt();
+	this->id = submission.value("id").toInt();
+	int problemId = submission.value("problem").toInt();
 	if (problems.contains(problemId)) {
 		this->problem = problems[problemId];
 	} else {
 		this->problem = NULL;
 	}
 
-	int teamId = submission.value("team").toString("0").toInt();
+	int teamId = submission.value("team").toInt();
 	if (teams.contains(teamId)) {
 		this->team = teams[teamId];
 	} else {
 		this->team = NULL;
 	}
 
-	this->time = QDateTime::fromTime_t(qRound(submission.value("time").toString().toDouble(0)));
+	this->time = QDateTime::fromTime_t(qRound(submission.value("time").toDouble(0)));
 }
 
 int Submission::getId() {

--- a/team.cpp
+++ b/team.cpp
@@ -7,9 +7,9 @@
 namespace DJ {
 namespace Model {
 Team::Team(QJsonObject team, QHash<int, Category *> categories, QObject *parent) : QObject(parent) {
-	this->id = team.value("id").toString("0").toInt();
+	this->id = team.value("id").toInt();
 	this->name = team.value("name").toString("UNKNOWN");
-	int categoryId = team.value("category").toString("0").toInt();
+	int categoryId = team.value("category").toInt();
 	if (categories.contains(categoryId)) {
 		this->category = categories[categoryId];
 		this->category->addTeam(this);


### PR DESCRIPTION
Here is the patch, do with it what you want.
I removed toString() in all places it was followed by a toInt or toDouble (for times).

times and contest data can be seen correctly.

the live view does not work.